### PR TITLE
Preserve case in templates

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -14,6 +14,7 @@ export default {
 
     // Config for html-minifier.
     htmlMinifier: {
+        caseSensitive: true,
         customAttrSurround: [[/@/, new RegExp('')], [/:/, new RegExp('')]],
         collapseWhitespace: true,
         removeComments: true

--- a/test/expects/compileTemplateLocalComponent.js
+++ b/test/expects/compileTemplateLocalComponent.js
@@ -1,4 +1,4 @@
-var compileTemplate = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',[_c('Msg')],  1)},staticRenderFns: [],
+var compileTemplateLocalComponent = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',[_c('Msg')],1)},staticRenderFns: [],
   components: {
     Msg: {
       render: h => h('div', ['Hello']),

--- a/test/expects/compileTemplateLocalComponent.js
+++ b/test/expects/compileTemplateLocalComponent.js
@@ -1,0 +1,9 @@
+var compileTemplate = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',[_c('Msg')],  1)},staticRenderFns: [],
+  components: {
+    Msg: {
+      render: h => h('div', ['Hello']),
+    },
+  },
+};
+
+export default compileTemplateLocalComponent;

--- a/test/fixtures/compileTemplateLocalComponent.vue
+++ b/test/fixtures/compileTemplateLocalComponent.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <Msg></Msg>
+  </div>
+</template>
+
+<script>
+export default {
+  components: {
+    Msg: {
+      render: h => h('div', ['Hello']),
+    },
+  },
+}
+</script>

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ function test(name) {
                 modules: {
                     generateScopedName: '[name]__[local]'
                 },
-                compileTemplate: ['compileTemplate', 'slot', 'table', 'table-n-slot'].indexOf(name) > -1
+              compileTemplate: ['compileTemplate', 'compileTemplateLocalComponent', 'slot', 'table', 'table-n-slot'].indexOf(name) > -1
             })]
         }).then(function (bundle) {
             var result = bundle.generate({ format: 'es' })

--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,13 @@ function test(name) {
                 modules: {
                     generateScopedName: '[name]__[local]'
                 },
-              compileTemplate: ['compileTemplate', 'compileTemplateLocalComponent', 'slot', 'table', 'table-n-slot'].indexOf(name) > -1
+              compileTemplate: [
+                  'compileTemplate',
+                  'compileTemplateLocalComponent',
+                  'slot',
+                  'table',
+                  'table-n-slot'
+              ].indexOf(name) > -1
             })]
         }).then(function (bundle) {
             var result = bundle.generate({ format: 'es' })


### PR DESCRIPTION
Currently the compiled result of a template yields a lowercase version
while it should keep the original case.

Helps #81 .

/ping @znck
