### PR TITLE
Make optional dependencies really optional

### DIFF
--- a/src/script/coffee.js
+++ b/src/script/coffee.js
@@ -1,8 +1,6 @@
-import Compiler from 'coffeescript-compiler'
-
-const coffee = new Compiler()
-
 export default function (script) {
+    const Compiler = require('coffeescript-compiler')
+    const coffee = new Compiler()
     return new Promise((resolve, reject) => {
         coffee.compile(script.code, { bare: true }, (status, output) => {
             if (status === 0) {

--- a/src/style/less.js
+++ b/src/style/less.js
@@ -1,6 +1,5 @@
 export default async function (style, options) {
     const less = require('less')
-
     const { css, map } = await less.render(style.code, {
         sourceMap: {
             sourceMapFullFilename: style.id,

--- a/src/style/less.js
+++ b/src/style/less.js
@@ -1,6 +1,6 @@
-import less from 'less'
-
 export default async function (style, options) {
+    const less = require('less')
+
     const { css, map } = await less.render(style.code, {
         sourceMap: {
             sourceMapFullFilename: style.id,

--- a/src/style/scss.js
+++ b/src/style/scss.js
@@ -1,7 +1,7 @@
-import sass from 'node-sass'
 import debug from '../debug'
 
 export default function (style, options) {
+    const sass = require('node-sass')
     debug(`SASS: ${style.id}`)
     const { css, map } = sass.renderSync({
         file: style.id,

--- a/src/style/stylus.js
+++ b/src/style/stylus.js
@@ -1,6 +1,5 @@
-import stylus from 'stylus'
-
 export default async function (style, options) {
+    const stylus = require('stylus')
     const stylusObj = stylus(style.code, {...options.stylus})
         .set('filename', style.id)
         .set('sourcemap', {

--- a/src/template/pug.js
+++ b/src/template/pug.js
@@ -1,6 +1,5 @@
-import pug from 'pug'
-
 export default async function (template, extras, options) {
+    const pug = require('pug')
     const compiler = pug.compile(template, { filename: extras.id, ...options.pug })
 
     return compiler({css: extras.modules || {}})


### PR DESCRIPTION
Fixes #83 .

Changes proposed in this pull request:
- Each optional dependency now is required when the related function is actually used, not always at start.

/ping @znck

Didn't add tests for this because a test would be running the compiled version in node with and without the required packages, and I'm not sure if you want that...
