### PR TITLE
Trim templates before pug compiling (#86)

### DIFF
--- a/src/template/pug.js
+++ b/src/template/pug.js
@@ -1,6 +1,6 @@
 export default async function (template, extras, options) {
     const pug = require('pug')
-    const trim = typeof template === 'string' ? template.trim : template
+    const trim = typeof template === 'string' ? template.trim() : template
     const compiler = pug.compile(trim, { filename: extras.id, ...options.pug })
 
     return compiler({css: extras.modules || {}})

--- a/src/template/pug.js
+++ b/src/template/pug.js
@@ -1,6 +1,7 @@
 export default async function (template, extras, options) {
     const pug = require('pug')
-    const compiler = pug.compile(template, { filename: extras.id, ...options.pug })
+    const trim = typeof template === 'string' ? template.trim : template
+    const compiler = pug.compile(trim, { filename: extras.id, ...options.pug })
 
     return compiler({css: extras.modules || {}})
 }

--- a/test/expects/pug.js
+++ b/test/expects/pug.js
@@ -1,3 +1,3 @@
-var pug = { template: "<div class=\"pug__test keep-me\">foo</div>",cssModules: {"test":"pug__test"},};
+var pug = { template: "<div class=\"pug__test keep-me\"><article><p>foo</p></article></div>",cssModules: {"test":"pug__test"},};
 
 export default pug;

--- a/test/fixtures/pug.vue
+++ b/test/fixtures/pug.vue
@@ -1,5 +1,11 @@
 <template lang="pug">
-  div(class=css.test class='keep-me') foo
+
+
+  div(class=css.test class='keep-me') 
+    article
+      p foo
+
+      
 </template>
 
 <script lang="babel">

--- a/test/fixtures/pug.vue
+++ b/test/fixtures/pug.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-div(class=css.test class='keep-me') foo
+  div(class=css.test class='keep-me') foo
 </template>
 
 <script lang="babel">


### PR DESCRIPTION
Fixes #86 .

Changes proposed in this pull request:
- Trim templates code before pug-template compiling, so that the compiler works correctly however many indent before the first letter of the very first line.

/ping @znck
