### PR TITLE
Fix #86, deIndent template code before preprocessing

### DIFF
--- a/src/template/pug.js
+++ b/src/template/pug.js
@@ -1,7 +1,6 @@
 export default async function (template, extras, options) {
     const pug = require('pug')
-    const trim = typeof template === 'string' ? template.trim() : template
-    const compiler = pug.compile(trim, { filename: extras.id, ...options.pug })
+    const compiler = pug.compile(template, { filename: extras.id, ...options.pug })
 
     return compiler({css: extras.modules || {}})
 }

--- a/src/template/pug.js
+++ b/src/template/pug.js
@@ -1,6 +1,6 @@
 export default async function (template, extras, options) {
     const pug = require('pug')
-    const compiler = pug.compile(template, { filename: extras.id, ...options.pug })
+    const compiler = pug.compile(template, { filename: extras.id, doctype: 'html', ...options.pug })
 
     return compiler({css: extras.modules || {}})
 }

--- a/src/vueTransform.js
+++ b/src/vueTransform.js
@@ -52,7 +52,7 @@ async function processTemplate (source, id, content, options, nodes, modules) {
     debug(`Process template: ${id}`)
 
     const extras = { modules, id, lang: source.attrs.lang }
-    const { code } = source
+    const code = deIndent(source.code)
     const template = deIndent(
           await (options.disableCssModuleStaticReplacement !== true
                 ? templateProcessor(code, extras, options)

--- a/src/vueTransform.js
+++ b/src/vueTransform.js
@@ -53,10 +53,10 @@ async function processTemplate (source, id, content, options, nodes, modules) {
 
     const extras = { modules, id, lang: source.attrs.lang }
     const code = deIndent(source.code)
-    const template = deIndent(
-          await (options.disableCssModuleStaticReplacement !== true
-                ? templateProcessor(code, extras, options)
-                : code)
+    const template = await (
+        options.disableCssModuleStaticReplacement !== true
+            ? templateProcessor(code, extras, options)
+            : code
     )
 
     if (!options.compileTemplate) {

--- a/test/expects/pug.js
+++ b/test/expects/pug.js
@@ -1,3 +1,3 @@
-var pug = { template: "<div class=\"pug__test keep-me\" v-if=\"true\"><article><p>foo</p></article></div><p v-else=\"v-else\">nothing</p>",cssModules: {"test":"pug__test"},};
+var pug = { template: "<div class=\"pug__test keep-me\" v-if=\"true\"><article><p>foo</p></article></div><p v-else>nothing</p>",cssModules: {"test":"pug__test"},};
 
 export default pug;

--- a/test/expects/pug.js
+++ b/test/expects/pug.js
@@ -1,3 +1,3 @@
-var pug = { template: "<div class=\"pug__test keep-me\"><article><p>foo</p></article></div>",cssModules: {"test":"pug__test"},};
+var pug = { template: "<div class=\"pug__test keep-me\" v-if=\"true\"><article><p>foo</p></article></div><p v-else=\"v-else\">nothing</p>",cssModules: {"test":"pug__test"},};
 
 export default pug;

--- a/test/fixtures/pug.vue
+++ b/test/fixtures/pug.vue
@@ -1,11 +1,13 @@
 <template lang="pug">
 
 
-  div(class=css.test class='keep-me') 
+  div(class=css.test class='keep-me' v-if="true")
     article
       p foo
+  p(v-else)
+    | nothing
 
-      
+
 </template>
 
 <script lang="babel">


### PR DESCRIPTION
Fixes #86. This should give template preprocessor more consistent code. vue-template-compiler also deindent before preprocessing.

/ping @znck
