### PR TITLE
Allow data option to prepend style to scss, less, stylus blocks

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -60,6 +60,9 @@ export default {
     // Config for node-sass.
     scss: {},
 
+    // Config for less.
+    less: {},
+
     // Config for stylus.
     stylus: {},
 

--- a/src/style/less.js
+++ b/src/style/less.js
@@ -1,12 +1,15 @@
 export default async function (style, options) {
     const less = require('less')
-    const { css, map } = await less.render(style.code, {
-        sourceMap: {
-            sourceMapFullFilename: style.id,
-            sourceMapFileInline: false
-        },
-        ...options.less
-    })
+    const { css, map } = await less.render(
+          'data' in options.less ? `${options.less.data}\n${style.code}` : style.code,
+        {
+            sourceMap: {
+                sourceMapFullFilename: style.id,
+                sourceMapFileInline: false
+            },
+            ...options.less
+        }
+    )
 
     style.$compiled = {
         code: css.toString(),

--- a/src/style/scss.js
+++ b/src/style/scss.js
@@ -5,7 +5,7 @@ export default function (style, options) {
     debug(`SASS: ${style.id}`)
     const { css, map } = sass.renderSync({
         file: style.id,
-        data: style.code,
+        data: 'data' in options.scss ? `${options.scss.data}\n${style.code}` : style.code,
         omitSourceMapUrl: true,
         sourceMap: true,
         outFile: style.id,

--- a/src/style/stylus.js
+++ b/src/style/stylus.js
@@ -1,10 +1,10 @@
 export default async function (style, options) {
     const stylus = require('stylus')
-    const stylusObj = stylus(style.code, {...options.stylus})
-        .set('filename', style.id)
-        .set('sourcemap', {
-            'comment': false
-        })
+    const stylusObj = stylus('data' in options.stylus ? `${options.stylus.data}\n${style.code}` : style.code, { ...options.stylus })
+          .set('filename', style.id)
+          .set('sourcemap', {
+              'comment': false
+          })
 
     const code = await stylusObj.render()
     const map = stylusObj.sourcemap


### PR DESCRIPTION
Fixes #93 

Changes proposed in this pull request:
- Prepends snippet set in `data` option of `scss`, `less` or `stylus` to each component.

