### PR TITLE
Add ability for lang="postcss" on style tags

### DIFF
--- a/src/style/index.js
+++ b/src/style/index.js
@@ -15,7 +15,7 @@ const compilers = {
 export async function compile (style, options) {
     let output
 
-    if (style.lang === 'css') {
+    if (style.lang === 'css' || style.lang === 'postcss') {
         output = await compileCSS(style, options)
     } else {
         output = await compileCSS(await compilers[style.lang].call(null, style, options), options)


### PR DESCRIPTION
Changes proposed in this pull request:
- Add ability to use `lang="postcss"` on `<style>` tags, this is needed for proper editor highlighting.

/ping @znck
