### PR TITLE
👐 Expose TypeScript declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "license": "MIT",
   "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vuejs/rollup-plugin-vue.git"


### PR DESCRIPTION
Just expose `rollup-plugin-vue`'s TypeScript declarations for TypeScript developers.

/ping @znck
