### PR TITLE
fix: Throw style compilation errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -209,13 +209,18 @@ export default function VuePlugin(opts: VuePluginOptions = {}): Plugin {
             ? hash(path.basename(filename) + source)
             : hash(filename + source))
         descriptors.set(filename, descriptor)
+
+        let styles = await Promise.all(
+          descriptor.styles.map(async style => {
+            let compiled = await compiler.compileStyleAsync(filename, scopeId, style)
+            if (compiled.errors.length > 0) throw Error(compiled.errors[0])
+            return compiled
+          })
+        )
+
         const input: any = {
           scopeId,
-          styles: await Promise.all(
-            descriptor.styles.map(style =>
-              compiler.compileStyleAsync(filename, scopeId, style)
-            )
-          ),
+          styles,
           customBlocks: []
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,9 +210,9 @@ export default function VuePlugin(opts: VuePluginOptions = {}): Plugin {
             : hash(filename + source))
         descriptors.set(filename, descriptor)
 
-        let styles = await Promise.all(
+        const styles = await Promise.all(
           descriptor.styles.map(async style => {
-            let compiled = await compiler.compileStyleAsync(filename, scopeId, style)
+            const compiled = await compiler.compileStyleAsync(filename, scopeId, style)
             if (compiled.errors.length > 0) throw Error(compiled.errors[0])
             return compiled
           })

--- a/test/forward-style-compiler-errors.spec.ts
+++ b/test/forward-style-compiler-errors.spec.ts
@@ -12,6 +12,5 @@ describe("forward-style-compiler-errors", () => {
         `, 'virtual-file.vue'
       )
     ).rejects.toBeInstanceOf(Error)
-    // expect(() => { throw Error()}).toThrow()
   })
 })

--- a/test/forward-style-compiler-errors.spec.ts
+++ b/test/forward-style-compiler-errors.spec.ts
@@ -1,0 +1,17 @@
+import pluginVue from '..'
+describe("forward-style-compiler-errors", () => {
+  it("throws", async () => {
+    let plugin = pluginVue()
+    await expect((plugin as any).transform(`
+        <template>
+        <div>Hello, world</div>
+        </template>
+        <style lang="scss">
+        @import 'file-not-exits.scss';
+        </style>
+        `, 'virtual-file.vue'
+      )
+    ).rejects.toBeInstanceOf(Error)
+    // expect(() => { throw Error()}).toThrow()
+  })
+})


### PR DESCRIPTION
Fixes #226.

Changes proposed in this pull request:
- forward the errors returned from `compileStyleAsync` to alert user that something has went wrong.

/ping @znck
