### PR TITLE
Bug fix so rollup-plugin-vue works with PostCSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-dist/
+# Removed dist from gitignore so package could be installed from repo
+# dist/
 /.github/sereno/public
 /_cache
 test/style.css

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,85 @@
+import { ScriptOptions, StyleOptions, TemplateOptions } from '@vue/component-compiler';
+import { Plugin } from 'rollup';
+import { VueTemplateCompiler, VueTemplateCompilerParseOptions } from '@vue/component-compiler-utils/dist/types';
+export interface VuePluginOptions {
+    /**
+     * Include files or directories.
+     * @default `'.vue'`
+     */
+    include?: Array<string | RegExp> | string | RegExp;
+    /**
+     * Exclude files or directories.
+     * @default `undefined`
+     */
+    exclude?: Array<string | RegExp> | string | RegExp;
+    /**
+     * Default language for blocks.
+     *
+     * @default `{}`
+     * @example
+     * ```js
+     * VuePlugin({ defaultLang: { script: 'ts' } })
+     * ```
+     */
+    defaultLang?: {
+        [key: string]: string;
+    };
+    /**
+     * Exclude customBlocks for final build.
+     * @default `['*']`
+     * @example
+     * ```js
+     * VuePlugin({ blackListCustomBlocks: ['markdown', 'test'] })
+     * ```
+     */
+    blackListCustomBlocks?: string[];
+    /**
+     * Include customBlocks for final build.
+     * @default `[]`
+     * @example
+     * ```js
+     * VuePlugin({ blackListCustomBlocks: ['markdown', 'test'] })
+     * ```
+     */
+    whiteListCustomBlocks?: string[];
+    /**
+     * Inject CSS in JavaScript.
+     * @default `true`
+     * @example
+     * ```js
+     * VuePlugin({ css: false }) // to extract css
+     * ```
+     */
+    css?: boolean;
+    compiler?: VueTemplateCompiler;
+    compilerParseOptions?: VueTemplateCompilerParseOptions;
+    sourceRoot?: string;
+    /**
+     * @@vue/component-compiler [#](https://github.com/vuejs/vue-component-compiler#api) script processing options.
+     */
+    script?: ScriptOptions;
+    /**
+     * @@vue/component-compiler [#](https://github.com/vuejs/vue-component-compiler#api) style processing options.
+     */
+    style?: StyleOptions;
+    /**
+     * @@vue/component-compiler [#](https://github.com/vuejs/vue-component-compiler#api) template processing options.
+     */
+    template?: TemplateOptions;
+    /**
+     * @@vue/component-compiler [#](https://github.com/vuejs/vue-component-compiler#api) module name or global function for custom runtime component normalizer.
+     */
+    normalizer?: string;
+    /**
+     * @@vue/component-compiler [#](https://github.com/vuejs/vue-component-compiler#api) module name or global function for custom style injector factory.
+     */
+    styleInjector?: string;
+    /**
+     * @@vue/component-compiler [#](https://github.com/vuejs/vue-component-compiler#api) module name or global function for custom style injector factory for SSR environment.
+     */
+    styleInjectorSSR?: string;
+}
+/**
+ * Rollup plugin for handling .vue files.
+ */
+export default function VuePlugin(opts?: VuePluginOptions): Plugin;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,174 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const utils_1 = require("./utils");
+const component_compiler_1 = require("@vue/component-compiler");
+const path = require("path");
+const component_compiler_utils_1 = require("@vue/component-compiler-utils");
+const debug_1 = require("debug");
+const templateCompiler = require('vue-template-compiler');
+const hash = require('hash-sum');
+const d = debug_1.default('rollup-plugin-vue');
+const { version } = require('../package.json');
+/**
+ * Rollup plugin for handling .vue files.
+ */
+function VuePlugin(opts = {}) {
+    const isVue = utils_1.createVueFilter(opts.include, opts.exclude);
+    const isProduction = process.env.NODE_ENV === 'production' || process.env.BUILD === 'production';
+    d('Version ' + version);
+    d(`Build environment: ${isProduction ? 'production' : 'development'}`);
+    d(`Build target: ${process.env.VUE_ENV || 'browser'}`);
+    if (!opts.normalizer)
+        opts.normalizer = '~vue-runtime-helpers/normalize-component.js';
+    if (!opts.styleInjector)
+        opts.styleInjector = '~vue-runtime-helpers/inject-style/browser.js';
+    if (!opts.styleInjectorSSR)
+        opts.styleInjectorSSR = '~vue-runtime-helpers/inject-style/server.js';
+    utils_1.createVuePartRequest.defaultLang = Object.assign({}, utils_1.createVuePartRequest.defaultLang, opts.defaultLang);
+    const shouldExtractCss = opts.css === false;
+    const blacklisted = new Set(opts.blackListCustomBlocks || ['*']);
+    const whitelisted = new Set(opts.whiteListCustomBlocks || []);
+    const isAllowed = (customBlockType) => (!blacklisted.has('*') || !blacklisted.has(customBlockType)) &&
+        (whitelisted.has('*') || whitelisted.has(customBlockType));
+    delete opts.css;
+    delete opts.blackListCustomBlocks;
+    delete opts.whiteListCustomBlocks;
+    delete opts.defaultLang;
+    delete opts.include;
+    delete opts.exclude;
+    opts.template = Object.assign({ transformAssetUrls: {
+            video: ['src', 'poster'],
+            source: 'src',
+            img: 'src',
+            image: 'xlink:href'
+        } }, opts.template);
+    if (opts.template && typeof opts.template.isProduction === 'undefined') {
+        opts.template.isProduction = isProduction;
+    }
+    const compiler = component_compiler_1.createDefaultCompiler(opts);
+    const descriptors = new Map();
+    if (opts.css === false)
+        d('Running in CSS extract mode');
+    return {
+        name: 'VuePlugin',
+        resolveId(id, importer) {
+            if (!utils_1.isVuePartRequest(id))
+                return;
+            id = path.resolve(path.dirname(importer), id);
+            const ref = utils_1.parseVuePartRequest(id);
+            if (ref) {
+                const element = utils_1.resolveVuePart(descriptors, ref);
+                const src = element.src;
+                if (ref.meta.type !== 'styles' && typeof src === 'string') {
+                    if (src.startsWith('.')) {
+                        return path.resolve(path.dirname(ref.filename), src);
+                    }
+                    else {
+                        return require.resolve(src, { paths: [path.dirname(ref.filename)] });
+                    }
+                }
+                else if (ref.meta.type === 'styles') {
+                    return id.replace('.vue', '.vue.css');
+                }
+                return id;
+            }
+        },
+        load(id) {
+            const request = utils_1.parseVuePartRequest(id);
+            if (!request)
+                return;
+            const element = utils_1.resolveVuePart(descriptors, request);
+            const code = 'code' in element
+                ? element.code // .code is set when extract styles is used. { css: false }
+                : element.content;
+            const map = element.map;
+            return { code, map };
+        },
+        transform(source, filename) {
+            return __awaiter(this, void 0, void 0, function* () {
+                if (isVue(filename)) {
+                    const descriptor = component_compiler_utils_1.parse({
+                        filename,
+                        source,
+                        compiler: opts.compiler || templateCompiler,
+                        compilerParseOptions: opts.compilerParseOptions,
+                        sourceRoot: opts.sourceRoot,
+                        needMap: true
+                    });
+                    const scopeId = 'data-v-' +
+                        (isProduction
+                            ? hash(path.basename(filename) + source)
+                            : hash(filename + source));
+                    descriptors.set(filename, descriptor);
+                    const styles = yield Promise.all(descriptor.styles.map((style) => __awaiter(this, void 0, void 0, function* () {
+                        if (!(typeof style.map.mappings === 'string')) {
+                            style.map.mappings = '';
+                        }
+                        const compiled = yield compiler.compileStyleAsync(filename, scopeId, style);
+                        if (compiled.errors.length > 0)
+                            throw Error(compiled.errors[0]);
+                        return compiled;
+                    })));
+                    const input = {
+                        scopeId,
+                        styles,
+                        customBlocks: []
+                    };
+                    if (descriptor.template) {
+                        input.template = compiler.compileTemplate(filename, descriptor.template);
+                        input.template.code = utils_1.transformRequireToImport(input.template.code);
+                        if (input.template.errors && input.template.errors.length) {
+                            input.template.errors.map((error) => this.error(error));
+                        }
+                        if (input.template.tips && input.template.tips.length) {
+                            input.template.tips.map((message) => this.warn({ message }));
+                        }
+                    }
+                    input.script = descriptor.script
+                        ? {
+                            code: `
+            export * from '${utils_1.createVuePartRequest(filename, descriptor.script.lang || 'js', 'script')}'
+            import script from '${utils_1.createVuePartRequest(filename, descriptor.script.lang || 'js', 'script')}'
+            export default script
+            `
+                        }
+                        : { code: '' };
+                    if (shouldExtractCss) {
+                        input.styles = input.styles
+                            .map((style, index) => {
+                            ;
+                            descriptor.styles[index].code = style.code;
+                            input.script.code +=
+                                '\n' +
+                                    `import '${utils_1.createVuePartRequest(filename, 'css', 'styles', index)}'`;
+                            if (style.module || descriptor.styles[index].scoped) {
+                                return Object.assign({}, style, { code: '' });
+                            }
+                        })
+                            .filter(Boolean);
+                    }
+                    const result = component_compiler_1.assemble(compiler, filename, input, opts);
+                    descriptor.customBlocks.forEach((block, index) => {
+                        if (!isAllowed(block.type))
+                            return;
+                        result.code +=
+                            '\n' +
+                                `export * from '${utils_1.createVuePartRequest(filename, block.attrs.lang ||
+                                    utils_1.createVuePartRequest.defaultLang[block.type] ||
+                                    block.type, 'customBlocks', index)}'`;
+                    });
+                    return result;
+                }
+            });
+        }
+    };
+}
+exports.default = VuePlugin;

--- a/dist/index.js
+++ b/dist/index.js
@@ -95,23 +95,20 @@ function VuePlugin(opts = {}) {
         transform(source, filename) {
             return __awaiter(this, void 0, void 0, function* () {
                 if (isVue(filename)) {
-                    const descriptor = component_compiler_utils_1.parse({
+                    const descriptor = JSON.parse(JSON.stringify(component_compiler_utils_1.parse({
                         filename,
                         source,
                         compiler: opts.compiler || templateCompiler,
                         compilerParseOptions: opts.compilerParseOptions,
                         sourceRoot: opts.sourceRoot,
                         needMap: true
-                    });
+                    })));
                     const scopeId = 'data-v-' +
                         (isProduction
                             ? hash(path.basename(filename) + source)
                             : hash(filename + source));
                     descriptors.set(filename, descriptor);
                     const styles = yield Promise.all(descriptor.styles.map((style) => __awaiter(this, void 0, void 0, function* () {
-                        if (!(typeof style.map.mappings === 'string')) {
-                            style.map.mappings = '';
-                        }
                         const compiled = yield compiler.compileStyleAsync(filename, scopeId, style);
                         if (compiled.errors.length > 0)
                             throw Error(compiled.errors[0]);

--- a/dist/utils.d.ts
+++ b/dist/utils.d.ts
@@ -1,0 +1,23 @@
+import { SFCDescriptor, SFCBlock, SFCCustomBlock } from '@vue/component-compiler-utils';
+export interface VuePartRequest {
+    filename: string;
+    meta: VuePartRequestMeta;
+}
+export interface VuePartRequestMeta {
+    type: 'template' | 'script' | 'styles' | 'customBlocks';
+    lang: string;
+    index?: number;
+}
+export interface VuePartRequestCreator {
+    (filename: string, lang: string, type: string, index?: number): string;
+    defaultLang: {
+        [key: string]: string;
+    };
+}
+export declare function createVueFilter(include?: Array<string | RegExp> | string | RegExp, exclude?: Array<string | RegExp> | string | RegExp): (file: string) => boolean;
+export declare function getVueMetaFromQuery(id: string): VuePartRequestMeta | null;
+export declare function isVuePartRequest(id: string): boolean;
+export declare const createVuePartRequest: VuePartRequestCreator;
+export declare function parseVuePartRequest(id: string): VuePartRequest | undefined;
+export declare function resolveVuePart(descriptors: Map<string, SFCDescriptor>, { filename, meta }: VuePartRequest): SFCBlock | SFCCustomBlock;
+export declare function transformRequireToImport(code: string): string;

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,0 +1,84 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const rollup_pluginutils_1 = require("rollup-pluginutils");
+const queryString = require("querystring");
+const path = require("path");
+const GET_QUERY = /\.vue(\.[a-z]+?)?\?(.+)$/i;
+const PARAM_NAME = 'rollup-plugin-vue';
+function createVueFilter(include = [/\.vue$/i], exclude = []) {
+    const filter = rollup_pluginutils_1.createFilter(include, exclude);
+    return id => filter(id);
+}
+exports.createVueFilter = createVueFilter;
+function getVueMetaFromQuery(id) {
+    const match = GET_QUERY.exec(id);
+    if (match) {
+        const query = queryString.parse(match[2]);
+        if (PARAM_NAME in query) {
+            const data = (Array.isArray(query[PARAM_NAME])
+                ? query[PARAM_NAME][0]
+                : query[PARAM_NAME]);
+            const [type, index, lang] = data.split('.');
+            return (lang
+                ? { type, lang, index: parseInt(index) } // styles.0.css
+                : { type, lang: index }); // script.js
+        }
+    }
+    return null;
+}
+exports.getVueMetaFromQuery = getVueMetaFromQuery;
+function isVuePartRequest(id) {
+    return getVueMetaFromQuery(id) !== null;
+}
+exports.isVuePartRequest = isVuePartRequest;
+exports.createVuePartRequest = ((filename, lang, type, index) => {
+    lang = lang || exports.createVuePartRequest.defaultLang[type];
+    const match = GET_QUERY.exec(filename);
+    const query = match ? queryString.parse(match[2]) : {};
+    query[PARAM_NAME] = [type, index, lang]
+        .filter(it => it !== undefined)
+        .join('.');
+    return `${path.basename(filename)}?${queryString.stringify(query)}`;
+});
+exports.createVuePartRequest.defaultLang = {
+    template: 'html',
+    styles: 'css',
+    script: 'js'
+};
+function parseVuePartRequest(id) {
+    if (!id.includes('.vue'))
+        return;
+    const filename = id.substr(0, id.lastIndexOf('.vue') + 4);
+    const params = getVueMetaFromQuery(id);
+    if (params === null)
+        return;
+    return {
+        filename,
+        meta: params
+    };
+}
+exports.parseVuePartRequest = parseVuePartRequest;
+function resolveVuePart(descriptors, { filename, meta }) {
+    const descriptor = descriptors.get(filename);
+    if (!descriptor)
+        throw Error('File not processed yet, ' + filename);
+    const blocks = descriptor[meta.type];
+    const block = Array.isArray(blocks) ? blocks[meta.index] : blocks;
+    if (!block)
+        throw Error(`Requested (type=${meta.type} & index=${meta.index}) block not found in ${filename}`);
+    return block;
+}
+exports.resolveVuePart = resolveVuePart;
+function transformRequireToImport(code) {
+    const imports = {};
+    let strImports = '';
+    code = code.replace(/require\(("(?:[^"\\]|\\.)+"|'(?:[^'\\]|\\.)+')\)/g, (_, name) => {
+        if (!(name in imports)) {
+            imports[name] = `__$_require_${name.replace(/[^a-z0-9]/g, '_').replace(/_{2,}/g, '_').replace(/^_|_$/g, '')}__`;
+            strImports += 'import ' + imports[name] + ' from ' + name + '\n';
+        }
+        return imports[name];
+    });
+    return strImports + code;
+}
+exports.transformRequireToImport = transformRequireToImport;

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ export default function VuePlugin(opts: VuePluginOptions = {}): Plugin {
           }
         }
         else if(ref.meta.type === 'styles') {
-            return id.replace('.vue', '.vue.css');
+          return id.replace('.vue', '.vue.css');
         }
 
         return id
@@ -197,14 +197,14 @@ export default function VuePlugin(opts: VuePluginOptions = {}): Plugin {
 
     async transform(source: string, filename: string) {
       if (isVue(filename)) {
-        const descriptor = parse({
+        const descriptor: SFCDescriptor = JSON.parse(JSON.stringify(parse({
           filename,
           source,
           compiler: opts.compiler || templateCompiler,
           compilerParseOptions: opts.compilerParseOptions,
           sourceRoot: opts.sourceRoot,
           needMap: true
-        })
+        })))
 
         const scopeId =
           'data-v-' +
@@ -215,9 +215,6 @@ export default function VuePlugin(opts: VuePluginOptions = {}): Plugin {
 
         const styles = await Promise.all(
           descriptor.styles.map(async style => {
-            if(!(typeof style.map.mappings === 'string')) {
-              style.map.mappings = '';
-            }
             const compiled = await compiler.compileStyleAsync(filename, scopeId, style)
             if (compiled.errors.length > 0) throw Error(compiled.errors[0])
             return compiled

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,9 @@ export default function VuePlugin(opts: VuePluginOptions = {}): Plugin {
 
         const styles = await Promise.all(
           descriptor.styles.map(async style => {
+            if(!(typeof style.map.mappings === 'string')) {
+              style.map.mappings = '';
+            }
             const compiled = await compiler.compileStyleAsync(filename, scopeId, style)
             if (compiled.errors.length > 0) throw Error(compiled.errors[0])
             return compiled

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,9 @@ export default function VuePlugin(opts: VuePluginOptions = {}): Plugin {
             return require.resolve(src, { paths: [path.dirname(ref.filename)] })
           }
         }
+        else if(ref.meta.type === 'styles') {
+            return id.replace('.vue', '.vue.css');
+        }
 
         return id
       }


### PR DESCRIPTION
Apologies if this isn't a good fix. It works for me, but it's entirely possible there is a better solution. I seem to notice in older versions of the plugin, the css files has .css extensions and now they do not. Perhaps this was the source of the issue, or I am completely wrong and the files never had .css. Hope this helps.

https://github.com/vuejs/rollup-plugin-vue/issues/241

Fixes #.

Changes proposed in this pull request:
-
-
-

/ping @znck
