### PR TITLE
fix: Copies SFCDescriptor before further passing it to processors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -194,14 +194,14 @@ export default function VuePlugin(opts: VuePluginOptions = {}): Plugin {
 
     async transform(source: string, filename: string) {
       if (isVue(filename)) {
-        const descriptor = parse({
+        const descriptor: SFCDescriptor = JSON.parse(JSON.stringify(parse({
           filename,
           source,
           compiler: opts.compiler || templateCompiler,
           compilerParseOptions: opts.compilerParseOptions,
           sourceRoot: opts.sourceRoot,
           needMap: true
-        })
+        })))
 
         const scopeId =
           'data-v-' +


### PR DESCRIPTION
scss processor modifies descriptor.styles[x].map.mappings and
`parse` function from `component-compiler-utils` caches the parsing
result. These two combined would cause a bug when rolling-up
multiple-output configuration since the descriptor is modified and
cached in the first turn and causing successive turns to fail.

Fixes #241 #239 .

Changes proposed in this pull request:
- copies SFCDescriptor before further manipulating it as https://github.com/vuejs/component-compiler-utils/pull/35#issuecomment-433740673 says

/ping @znck
