### PR TITLE
fix: Properly encode testfixture imports

### DIFF
--- a/test/setup/plugins.ts
+++ b/test/setup/plugins.ts
@@ -44,7 +44,7 @@ export function pluginCreateVueApp(filename: string, component: string): any {
     load(id) {
       if (id === filename)
         return `
-    import Component from '${component}'
+    import Component from ${JSON.stringify(component)}
 
     Vue.config.productionTip = false
     Vue.config.devtools = false


### PR DESCRIPTION
Fixes #253 

Changes proposed in this pull request:
- use `JSON.stringify()` to JS-encode import paths
- this fixes tests on Windows

/ping @znck
