### PR TITLE
chore: Upgrade rollup-pluginutils

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "hash-sum": "^1.0.2",
     "magic-string": "^0.25.2",
     "querystring": "^0.2.0",
-    "rollup-pluginutils": "^2.0.1",
+    "rollup-pluginutils": "^2.4.1",
     "source-map": "0.7.3",
     "vue-runtime-helpers": "1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4159,6 +4159,11 @@ estree-walker@^0.5.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
   integrity sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==
 
+estree-walker@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.0.tgz#5d865327c44a618dde5699f763891ae31f257dae"
+  integrity sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -9006,6 +9011,14 @@ rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.1, rollup-pluginutils@^1.5.2:
   dependencies:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
+
+rollup-pluginutils@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.4.1.tgz#de43ab54965bbf47843599a7f3adceb723de38db"
+  integrity sha512-wesMQ9/172IJDIW/lYWm0vW0LiKe5Ekjws481R7z9WTRtmO59cqyM/2uUlxvf6yzm/fElFmHUobeQOYz46dZJw==
+  dependencies:
+    estree-walker "^0.6.0"
+    micromatch "^3.1.10"
 
 rollup@^0.34.7:
   version "0.34.13"


### PR DESCRIPTION
Fixes N/A. I haven't logged it as an issue. Let me know if it's required!

Changes proposed in this pull request:
- Upgrade `rollup-pluginutils`

Running `yarn audit` in a project using latest version of `rollup-plugin-vue` (at the time of writing `4.7.2`) has 2 low level security issues. Both of which are a result of outdated `rollup-pluginutils`. Latest version of `rollup-pluginutils` is a minor upgrade and uses latest version of `braces` which doesn't have the "Regular Expression Denial of Service" issue. As for the "Cryptographically Weak PRNG" issue - `braces` package no longer depends on `expand-rage`.

I also ran the tests after upgrade, just for safe measure, and all tests passed.
```
yarn audit v1.13.0
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ braces                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.3.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ rollup-plugin-vue                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ rollup-plugin-vue > rollup-pluginutils > micromatch > braces │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/786                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Cryptographically Weak PRNG                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ randomatic                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=3.0.0                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ rollup-plugin-vue                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ rollup-plugin-vue > rollup-pluginutils > micromatch > braces │
│               │ > expand-range > fill-range > randomatic                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/157                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```

/ping @znck
