### PR TITLE
chore: Upgrade vue-runtime-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "querystring": "^0.2.0",
     "rollup-pluginutils": "^2.4.1",
     "source-map": "0.7.3",
-    "vue-runtime-helpers": "1.0.0"
+    "vue-runtime-helpers": "1.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.46",
@@ -71,7 +71,6 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "conventional-changelog": "^3.0.5",
     "jest": "^23.6.0",
-    "sass": "^1.18.0",
     "postcss": "^7.0.11",
     "postcss-assets": "^5.0.0",
     "prettier": "^1.12.1",
@@ -87,6 +86,7 @@
     "rollup-plugin-typescript": "^1.0.0",
     "rollup-plugin-typescript2": "^0.18.1",
     "rollup-plugin-url": "^2.1.0",
+    "sass": "^1.18.0",
     "ts-jest": "^23.10.5",
     "typescript": "^3.2.2",
     "vue": "^2.5.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10264,10 +10264,10 @@ vue-router@^3.0.1:
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.0.2.tgz#dedc67afe6c4e2bc25682c8b1c2a8c0d7c7e56be"
   integrity sha512-opKtsxjp9eOcFWdp6xLQPLmRGgfM932Tl56U9chYTnoWqKxQ8M20N7AkdEbM5beUh6wICoFGYugAX9vQjyJLFg==
 
-vue-runtime-helpers@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/vue-runtime-helpers/-/vue-runtime-helpers-1.0.0.tgz#af5fe1c8d727beb680b2eb9d791c8e022342e54d"
-  integrity sha512-DgwCNgIXkq1GJsWwtFOjA/K2nxpjyon/QqAut0EiwrMHBatAPbfdqksDdRoK15b5YrSJRa59rx3pc0L6V4udUA==
+vue-runtime-helpers@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vue-runtime-helpers/-/vue-runtime-helpers-1.0.1.tgz#9a7f527d43fdecf83638188fb0e5bae699c2b5bb"
+  integrity sha512-yodqdAWt/QrUkb51jN2DS4dtF4vQWg5YejYdBAcHIOi6kBoGLRVEDz5NYGdh5IhzLrElgi+eKX1DQJmj3bCuJw==
 
 vue-server-renderer@^2.5.16:
   version "2.5.22"


### PR DESCRIPTION
Fixes #263 (I think). Testing locally fixed the SSR problems I was seeing related to `document is undefined` when looking for head that was replaced [here](https://github.com/znck/vue-runtime-helpers/commit/02d9dfaf54388128a7eac8013f0af6526f6e8586)

Changes proposed in this pull request:
- Upgrade `vue-runtime-helpers`

/ping @znck
