### PR TITLE
fix: generate compiler per component to pass information about scopeId

### DIFF
--- a/cookbook/ssr/package.json
+++ b/cookbook/ssr/package.json
@@ -5,7 +5,7 @@
   },
   "main": "./dist/MyComponent.js",
   "devDependencies": {
-    "rollup": "^0.59.4",
+    "rollup": "^1.1.0",
     "rollup-plugin-vue": "link:../.."
   }
 }

--- a/cookbook/ssr/src/MyComponent.vue
+++ b/cookbook/ssr/src/MyComponent.vue
@@ -1,5 +1,7 @@
 <template>
-  <h1>Hello {{ name }}</h1>
+  <div class="component-root-node">
+    <h1>Hello {{ name }}</h1>
+  </div>
 </template>
 
 <script>
@@ -11,6 +13,10 @@ export default {
 </script>
 
 <style scoped>
+.component-root-node {
+  background: blue;
+}
+
 h1 {
   color: red;
 }


### PR DESCRIPTION
Fixes #321

Changes proposed in this pull request:
- Generate compiler instance per component so component `scopeId` can be passed as a variable to generate correctly optimised SSR code.

I tried to add tests for that but it seems that currently tests enviroment supports only `iife` build.

/ping @znck