### PR TITLE
fix: cannot load custom block

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export default function PluginVue(userOptions: Partial<Options> = {}): Plugin {
               ? descriptor.script!
               : query.type === 'style'
               ? descriptor.styles[query.index]
-              : query.type === 'custom'
+              : filterCustomBlock(query.type)
               ? descriptor.customBlocks[query.index]
               : null
 


### PR DESCRIPTION
for example,  if request query is `/entry.vue?vue&type=i18n&index=0&lang.json`, cannot `load` custom block content.

/ping @znck
