### PR TITLE
Use script.render as default when there's no <template>

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -427,7 +427,7 @@ function getTemplateCode(
   hasScoped: boolean,
   isServer: boolean
 ) {
-  let templateImport = `const render = () => {}`
+  let templateImport = `const render = script.render || (() => {})`
   let templateRequest
   if (descriptor.template) {
     const src = descriptor.template.src || resourcePath

--- a/src/index.ts
+++ b/src/index.ts
@@ -427,7 +427,7 @@ function getTemplateCode(
   hasScoped: boolean,
   isServer: boolean
 ) {
-  let templateImport = `const render = script.render || (() => {})`
+  let templateImport = `const render = script.${isServer ? 'ssrRender' : 'render'} || (() => {})`
   let templateRequest
   if (descriptor.template) {
     const src = descriptor.template.src || resourcePath


### PR DESCRIPTION
For SFC without `<template>` like:

```vue
<script>
import { h } from 'vue';

export default {
  render: () => h('div'),
};
</script>
```

I think it should use `script.render` as default.

/ping @znck
