### PR TITLE
docs: reference new rollup commonjs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ With rollup you can break your application into reusable modules.
 > This document applies to v4.0+. If you are looking for older versions, docs are [here](https://github.com/vuejs/rollup-plugin-vue/tree/2.2/docs)
 
 ```js
-import commonjs from 'rollup-plugin-commonjs' 
+import commonjs from '@rollup/plugin-commonjs' 
 import VuePlugin from 'rollup-plugin-vue'
 
 export default {


### PR DESCRIPTION
Fixes minor doc detail.

Changes proposed in this pull request:
- Seems [rollup-plugin-commonjs](https://github.com/rollup/rollup-plugin-commonjs) has been moved to [@rollup/plugin-commonjs](https://github.com/rollup/plugins/tree/master/packages/commonjs)

/ping @znck
