### PR TITLE
feat: keep custom block type when block has lang

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -483,10 +483,10 @@ export default function vue(opts: Partial<VuePluginOptions> = {}): Plugin {
             `export * from '${createVuePartRequest(
               filename,
               (typeof block.attrs.lang === 'string' && block.attrs.lang) ||
-                createVuePartRequest.defaultLang[block.type] ||
-                block.type,
+                createVuePartRequest.defaultLang[block.type],
               'customBlocks',
-              index
+              index,
+              block.type
             )}'`
         })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -478,16 +478,19 @@ export default function vue(opts: Partial<VuePluginOptions> = {}): Plugin {
 
         descriptor.customBlocks.forEach((block, index) => {
           if (!isAllowed(block.type)) return
+          const vuePartRequest = createVuePartRequest(
+            filename,
+            (typeof block.attrs.lang === 'string' && block.attrs.lang) ||
+              createVuePartRequest.defaultLang[block.type],
+            'customBlocks',
+            index,
+            block.type
+          )
           result.code +=
             '\n' +
-            `export * from '${createVuePartRequest(
-              filename,
-              (typeof block.attrs.lang === 'string' && block.attrs.lang) ||
-                createVuePartRequest.defaultLang[block.type],
-              'customBlocks',
-              index,
-              block.type
-            )}'`
+            `export * from '${vuePartRequest}'\n` +
+            `import __custom_block_${index}__ from '${vuePartRequest}'\n` +
+            `__custom_block_${index}__(__vue_component__)`
         })
 
         dT(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,13 @@ export interface VuePartRequestMeta {
 }
 
 export interface VuePartRequestCreator {
-  (filename: string, lang: string, type: string, index?: number): string
+  (
+    filename: string,
+    lang: string,
+    type: string,
+    index?: number,
+    blockType?: string
+  ): string
 
   defaultLang: {
     [key: string]: string
@@ -68,7 +74,8 @@ export const createVuePartRequest: VuePartRequestCreator = ((
   filename: string,
   lang: string | undefined,
   type: string,
-  index?: number
+  index?: number,
+  blockType?: string
 ): string => {
   lang = lang || createVuePartRequest.defaultLang[type]
 
@@ -76,7 +83,7 @@ export const createVuePartRequest: VuePartRequestCreator = ((
 
   const query = match ? queryString.parse(match[2]) : {}
 
-  query[PARAM_NAME] = [type, index, lang]
+  query[PARAM_NAME] = [type, index, blockType, lang]
     .filter(it => it !== undefined)
     .join('.')
 


### PR DESCRIPTION
Fixes #333 .

Changes proposed in this pull request:
- Separate custom block type from lang.

When SFC custom block has a lang attribute, the block type will lost in the current version. It makes [rollup-plugin-vue-i18n](https://github.com/intlify/rollup-plugin-vue-i18n) cannot detect the custom block.


/ping @znck
