### PR TITLE
Make all TemplateOptions types optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ export interface VuePluginOptions {
   /**
    * @@vue/component-compiler [#](https://github.com/vuejs/vue-component-compiler#api) template processing options.
    */
-  template?: TemplateOptions
+  template?: Partial<TemplateOptions>
   /**
    * @@vue/component-compiler [#](https://github.com/vuejs/vue-component-compiler#api) module name or global function for custom runtime component normalizer.
    */


### PR DESCRIPTION
Make compiler and compilerOptions properties optional

Fixes type issues where compiler and compilerOptions are required in the TemplateOptions interface but are not expected in the vue plugin options.

Changes proposed in this pull request:
- Wrap `Partial<..>` around `TemplateOptions`

/ping @znck
