### PR TITLE
fix: default render function name for ssr

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -466,7 +466,8 @@ function getTemplateCode(
   hasScoped: boolean,
   isServer: boolean
 ) {
-  let templateImport = `const render = () => {}`
+  const renderFnName = isServer ? 'ssrRender' : 'render'
+  let templateImport = `const ${renderFnName} = () => {}`
   let templateRequest
   if (descriptor.template) {
     const src = descriptor.template.src || resourcePath
@@ -476,9 +477,7 @@ function getTemplateCode(
     const attrsQuery = attrsToQuery(descriptor.template.attrs)
     const query = `?vue&type=template${idQuery}${srcQuery}${scopedQuery}${attrsQuery}`
     templateRequest = _(src + query)
-    templateImport = `import { ${
-      isServer ? 'ssrRender' : 'render'
-    } } from ${templateRequest}`
+    templateImport = `import { ${renderFnName} } from ${templateRequest}`
   }
 
   return templateImport


### PR DESCRIPTION
Changes proposed in this pull request:
- The default `templateImport` should also be aware of the `isServer` flag

Similar to https://github.com/vuejs/vue-loader/blob/a56585e707a69de41a1fd083f5f2018e271d1e1c/src/index.ts#L155

/ping @znck
